### PR TITLE
Some nice changes to getAvatarMaterial

### DIFF
--- a/material-avatar.lua
+++ b/material-avatar.lua
@@ -8,7 +8,7 @@ local function getAvatarMaterial(steamid64, callback)
 		local time_since_creation = os.time() - file.Time("avatars/" .. steamid64 .. ".png", "DATA")
 		-- If the file exists (0 = does not exist) and is less than 1 day old, load it as a fallback.
 		if time_since_creation ~= 0 and time_since_creation < AVATAR_IMAGE_CACHE_EXPIRES then
-			fallback = Material("data/avatars/" .. steamid64 .. ".png", "smooth")
+			fallback = Material("data/avatars/" .. steamid64 .. ".png", "smooth mips")
 		end
 	end
 
@@ -50,7 +50,7 @@ local function getAvatarMaterial(steamid64, callback)
 					file.CreateDir("avatars")
 					file.Write(cachePath, body) -- Write the avatar to data/
 
-					local material = Material("data/" .. cachePath, "smooth") -- Load the avatar from data/ as a Material
+					local material = Material("data/" .. cachePath, "smooth mips") -- Load the avatar from data/ as a Material
 					if material:IsError() then
 						-- If the material errors, the image must be corrupt, so we'll delete this from data/ and return the fallback.
 						file.Delete(cachePath)

--- a/material-avatar.lua
+++ b/material-avatar.lua
@@ -4,9 +4,12 @@ local function getAvatarMaterial(steamid64, callback)
 	-- First, check the cache to see if this avatar has already been downloaded.
 	-- If the avatar hasn't been cached in data/, file.Time will return 0.
 	-- If an avatar material is 1 day old, let's redownload it but use it as a fallback in case something goes wrong.
-	local fallback
-	if os.time() - file.Time("avatars/" .. steamid64 .. ".png", "DATA") > AVATAR_IMAGE_CACHE_EXPIRES then
-		fallback = Material("data/avatars/" .. steamid64 .. ".png", "smooth")
+	local fallback; do
+		local time_since_creation = os.time() - file.Time("avatars/" .. steamid64 .. ".png", "DATA")
+		-- If the file exists (0 = does not exist) and is less than 1 day old, load it as a fallback.
+		if time_since_creation ~= 0 and time_since_creation < AVATAR_IMAGE_CACHE_EXPIRES then
+			fallback = Material("data/avatars/" .. steamid64 .. ".png", "smooth")
+		end
 	end
 
 	-- If a fallback couldn't be found in data/, default to vgui/avatar_default

--- a/material-avatar.lua
+++ b/material-avatar.lua
@@ -12,9 +12,17 @@ local function getAvatarMaterial(steamid64, callback)
 		end
 	end
 
+	-- Bots' SteamID64s start with 900, so we can use this to determine if the player is a bot or not.
+	local isBot = steamid64:StartsWith("900")
+
 	-- If a fallback couldn't be found in data/, default to vgui/avatar_default
-	if not fallback or fallback:IsError() then
+	if isBot or not fallback or fallback:IsError() then
 		fallback = Material("vgui/avatar_default")
+
+		-- If the player is a bot, we don't need to download their avatar, so return the fallback.
+		if isBot then
+			return callback(fallback)
+		end
 	else
 		-- Otherwise, if a cached avatar was found, and it hasn't expired, return it!
 		return callback(fallback)

--- a/material-avatar.lua
+++ b/material-avatar.lua
@@ -22,7 +22,7 @@ local function getAvatarMaterial(steamid64, callback)
 	-- Fetch the XML version of the player's Steam profile.
 	-- This XML contains a tag, <avatarFull> which contains the URL to their full avatar.
 	http.Fetch("https://steamcommunity.com/profiles/" .. steamid64 .. "?xml=1",
-	
+
 		function(body, size, headers, code)
 			-- If the HTTP request fails (size = 0, code is not a HTTP success response code) then return the fallback
 			if size == 0 or code < 200 or code > 299 then return callback(fallback, steamid64) end
@@ -33,7 +33,7 @@ local function getAvatarMaterial(steamid64, callback)
 
 			-- Download the avatar image
 			http.Fetch(url .. fileType,
-				
+
 				function(body, size, headers, code)
 					if size == 0 or code < 200 or code > 299 then return callback(fallback, steamid64) end
 
@@ -58,7 +58,7 @@ local function getAvatarMaterial(steamid64, callback)
 
 			)
 		end,
-		
+
 		-- If we hard-fail, return the fallback image.
 		function() callback(fallback, steamid64) end
 	)


### PR DESCRIPTION
- Use PNG as file ext, no need to check file ext type, as `Material` function will work even if the file format doesn't match.
- Fix a bug where it never loads from cache because it was checking if `100` (example) > `AVATAR_IMAGE_CACHE_EXPIRES = 86400` (It only loaded it if it was expired lol)
- Handle a case for bots to avoid doing an HTTP request for them.
- Add `mips` to `Material` to make sure it looks good on different scales.